### PR TITLE
Fix newline in .gitignore and expand ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+*.log
+.env


### PR DESCRIPTION
## Summary
- fix missing trailing newline in `.gitignore`
- ignore `*.log` files and `.env`

## Testing
- `npm run check` *(fails: Declaration or statement expected in Business_backup.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8e4ae088332a828365b0297b97c