### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+node_modules
+.git
+attached_assets
+client/public/figmaAssets
+# Build directories
+build
+out
+dist
+# Logs
+*.log
+npm-debug.log*
+# Environment files
+.env
+.env.*
+# IDE files
+.vscode
+.DS_Store
+coverage
+client/.svelte-kit


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep Docker build context small

## Testing
- `docker build -t test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8ccc1b083329f2473ec4502ebdb